### PR TITLE
Fix: Invalid name value in package.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/*
 node_modules

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ const scaffoldProject = () => {
         type: "list",
         name: "structureType",
         message: "Choose the structure you want to scaffold:",
-        choices: ["Monorepo (npm workspaces)", "Single App"],
+        choices: ["Single application", "Monorepo (npm workspaces)"],
+        default: "Monorepo (npm workspaces)",
       },
     ])
     .then(async (answers) => {
@@ -116,7 +117,7 @@ const scaffoldProject = () => {
                 } else {
                   console.log(
                     chalk.yellow(
-                      `⚠️ You chose not to install dependencies. Run 'npm install' manually when ready.`
+                      `⚠️  You chose not to install dependencies. Run 'npm install' manually when ready.`
                     )
                   );
                 }

--- a/index.js
+++ b/index.js
@@ -28,7 +28,12 @@ const scaffoldProject = () => {
       },
     ])
     .then(async (answers) => {
-      const { projectName, structureType } = answers;
+      let { projectName, structureType } = answers;
+
+      // Handle case when project name contains more than one word
+
+      // Replace spaces in the project name with hyphens
+      projectName = projectName.split(" ").join("-");
 
       // Define the path where the new project will be created
       const projectPath = path.join(process.cwd(), projectName);

--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ const scaffoldProject = () => {
         if (structureType === "Single App")
           transformMonorepoToSingleApp({ projectPath });
 
+        renameProjectNameInPackageJson({ projectPath, projectName });
+        
         // for MONOREPO just pull all the code
 
         // Step 10: Prompt to initialize git repository
@@ -318,6 +320,38 @@ const transformMonorepoToSingleApp = ({ projectPath }) => {
     console.log(chalk.green(`✅ Updated 'components.json' for Single App.`));
   }
 };
+
+const renameProjectNameInPackageJson = ({ projectPath, projectName }) => { 
+  const rootPackageJsonPath = path.join(projectPath, "package.json");
+  const lockFilePath = path.join(projectPath, "package-lock.json");
+    
+  if (fs.existsSync(rootPackageJsonPath)) {
+      const rootPackageJson = JSON.parse(
+          fs.readFileSync(rootPackageJsonPath, "utf8")
+      );
+      
+      // Update the name field in package.json
+      rootPackageJson.name = projectName; // Set the name from user input
+      fs.writeFileSync(rootPackageJsonPath, JSON.stringify(rootPackageJson, null, 2));
+  } else {
+      console.error(chalk.red(`❌ 'package.json' not found in the cloned project.`));
+      process.exit(1);
+  }
+
+  // Update the name field in package-lock.json if it exists
+  if (fs.existsSync(lockFilePath)) {
+      const lockFile = JSON.parse(
+          fs.readFileSync(lockFilePath, "utf8")
+      );
+      
+      // Update the name field
+      lockFile.name = projectName; // Set the name from user input
+      lockFile.packages[""].name = projectName; // Set the name at the root level
+      fs.writeFileSync(lockFilePath, JSON.stringify(lockFile, null, 2));
+  } else {
+      console.error(chalk.red(`❌ 'package-lock.json' not found in the cloned project.`));
+  }
+}
 
 const program = new Command();
 


### PR DESCRIPTION
## Modifications

### Reordered project types with the following order:
- Single application (Before was "Single App")
- Monorepo (set as the default and automatically selected)

![image](https://github.com/user-attachments/assets/ac766bbd-d832-4a8e-8c3f-0cf87d22ecab)

### Updated `.gitignore` file
Added `/*` to ensure all projects created by the CLI are ignored.

### Added additional blank space

#### Before
`⚠️ You chose not to install dependencies. Run 'npm install' manually when ready.`

#### After
 `⚠️  You chose not to install dependencies. Run 'npm install' manually when ready.`
